### PR TITLE
Add watch nodes capability in PX

### DIFF
--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "update", "list"]
+  verbs: ["watch", "get", "update", "list"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "update", "list"]
+  verbs: ["watch", "get", "update", "list"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]


### PR DESCRIPTION
I think we can merge this anyways event if the PX out in field does not use watch apis.