### PR TITLE
PWX-3927: Fix unconditional PX-OCI restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ TARGETS += px-spec-websvc/px-spec-websvc px-oci-mon/px-oci-mon
 # BUILD RULES
 #
 
-.PHONY: all deploy clean distclean vendor-pull px-container
+.PHONY: all deploy rmi clean distclean vendor-pull px-container
 
 all: $(TARGETS)
 
@@ -104,11 +104,13 @@ endif
 	$(SUDO) docker push $(DOCKER_HUB_REPO)/$(DOCKER_HUB_WEBSVC_IMAGE):latest
 endif
 
-clean:
-	rm -f $(TARGETS)
+rmi:
 	-$(SUDO) docker rmi -f $(WEBSVC_IMG) $(OCIMON_IMG) \
 	    $(DOCKER_HUB_REPO)/$(DOCKER_HUB_OCIMON_IMAGE):latest \
 	    $(DOCKER_HUB_REPO)/$(DOCKER_HUB_WEBSVC_IMAGE):latest
 
-distclean: clean
+clean:
+	rm -f $(TARGETS)
+
+distclean: rmi clean
 	@rm -fr vendor/github.com vendor/golang.org

--- a/px-oci-mon/main_test.go
+++ b/px-oci-mon/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsRestartRequired(t *testing.T) {
+	var data = []struct {
+		log         string
+		expectation bool
+	}{
+		{`time="2017-09-30T05:48:06Z" level=info msg="> Updated mounts: add{/var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/etc-hosts:/etc/hosts /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/containers/portworx/064db72c:/tmp/px-termination-log /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/volumes/kubernetes.io~secret/px-account-token-kx5pz:/var/run/secrets/kubernetes.io/serviceaccount:ro} rm{/var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/etc-hosts:/etc/hosts /var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/containers/portworx/a0f279f8:/tmp/px-termination-log /var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/volumes/kubernetes.io~secret/px-account-token-kx5pz:/var/run/secrets/kubernetes.io/serviceaccount:ro}"
+`, false},
+		{`time="2017-09-30T05:48:06Z" level=info msg="Rootfs found at /opt/pwx/oci/rootfs"
+time="2017-09-30T05:48:06Z" level=info msg="SPEC UPDATED [0892499e680147b53335759aa487886e  /opt/pwx/oci/config.json]"
+time="2017-09-30T05:48:06Z" level=info msg="> Updated mounts: add{/var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/etc-hosts:/etc/hosts /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/containers/portworx/064db72c:/tmp/px-termination-log /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/volumes/kubernetes.io~secret/px-account-token-kx5pz:/var/run/secrets/kubernetes.io/serviceaccount:ro} rm{/var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/etc-hosts:/etc/hosts /var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/containers/portworx/a0f279f8:/tmp/px-termination-log /var/lib/kubelet/pods/209b4313-a596-11e7-9508-5254007a695a/volumes/kubernetes.io~secret/px-account-token-kx5pz:/var/run/secrets/kubernetes.io/serviceaccount:ro}"
+time="2017-09-30T05:48:06Z" level=info msg="PX-RunC arguments: -a -c mycluster22 -d eth1 -f -k etcd://192.168.56.1:2379 -m eth1 -x kubernetes"
+time="2017-09-30T05:48:06Z" level=info msg="PX-RunC mounts: /dev/:/dev/ /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/etc-hosts:/etc/hosts /etc/pwx/:/etc/pwx/ /etc/resolv.conf:/etc/resolv.conf:ro /opt/pwx/bin/:/export_bin/ /lib/modules/:/lib/modules/ proc:/proc/:nosuid,noexec,nodev /run/docker/:/run/docker/ sysfs:/sys/:nosuid,noexec,nodev cgroup:/sys/fs/cgroup/:nosuid,noexec,nodev /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/containers/portworx/064db72c:/tmp/px-termination-log /usr/src/:/usr/src/ /var/cores/:/var/cores/ /var/run/:/var/host_run/ /var/lib/kubelet:/var/lib/kubelet:shared /var/lib/osd:/var/lib/osd:shared /var/lib/osd/:/var/lib/osd/:shared /var/lib/kubelet/pods/e5b67f9c-a5a2-11e7-922e-5254007a695a/volumes/kubernetes.io~secret/px-account-token-kx5pz:/var/run/secrets/kubernetes.io/serviceaccount:ro"
+time="2017-09-30T05:48:06Z" level=info msg="PX-RunC env: BTRFS_SOURCE=/home/px_btrfs GOMAXPROCS=64 GOTRACEBACK=crash KUBERNETES_PORT=tcp://10.96.0.1:443 KUBERNETES_PORT_443_TCP=tcp://10.96.0.1:443 KUBERNETES_PORT_443_TCP_ADDR=10.96.0.1 KUBERNETES_PORT_443_TCP_PORT=443 KUBERNETES_PORT_443_TCP_PROTO=tcp KUBERNETES_SERVICE_HOST=10.96.0.1 KUBERNETES_SERVICE_PORT=443 KUBERNETES_SERVICE_PORT_HTTPS=443 KUBE_DNS_PORT=udp://10.96.0.10:53 KUBE_DNS_PORT_53_TCP=tcp://10.96.0.10:53 KUBE_DNS_PORT_53_TCP_ADDR=10.96.0.10 KUBE_DNS_PORT_53_TCP_PORT=53 KUBE_DNS_PORT_53_TCP_PROTO=tcp KUBE_DNS_PORT_53_UDP=udp://10.96.0.10:53 KUBE_DNS_PORT_53_UDP_ADDR=10.96.0.10 KUBE_DNS_PORT_53_UDP_PORT=53 KUBE_DNS_PORT_53_UDP_PROTO=udp KUBE_DNS_SERVICE_HOST=10.96.0.10 KUBE_DNS_SERVICE_PORT=53 KUBE_DNS_SERVICE_PORT_DNS=53 KUBE_DNS_SERVICE_PORT_DNS_TCP=53 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORTWORX_SERVICE_PORT=tcp://10.110.109.163:9001 PORTWORX_SERVICE_PORT_9001_TCP=tcp://10.110.109.163:9001 PORTWORX_SERVICE_PORT_9001_TCP_ADDR=10.110.109.163 PORTWORX_SERVICE_PORT_9001_TCP_PORT=9001 PORTWORX_SERVICE_PORT_9001_TCP_PROTO=tcp PORTWORX_SERVICE_SERVICE_HOST=10.110.109.163 PORTWORX_SERVICE_SERVICE_PORT=9001 PXMOD_SOURCE=/home/px-fuse PXMOD_VERSION=5 PX_IMAGE=zoxpx/px-dev PX_RUNC=true TERM=xterm ZOX=was here..."
+time="2017-09-30T05:48:06Z" level=info msg="Successfully written /etc/systemd/system/portworx.service"
+time="2017-09-30T05:48:06Z" level=info msg="Stopping Portworx service (if any)"
+time="2017-09-30T05:48:06Z" level=info msg="> run: /bin/sh -c systemctl stop portworx"
+Warning: portworx.service changed on disk. Run 'systemctl daemon-reload' to reload units.
+time="2017-09-30T05:48:06Z" level=info msg="Starting Portworx service"
+time="2017-09-30T05:48:06Z" level=info msg="> run: /bin/sh -c systemctl daemon-reload && systemctl enable portworx && systemctl start portworx"
+time="2017-09-30T05:48:07Z" level=info msg="Install done - going to sleep"`, false},
+		{`INFO[0000] Rootfs found at /opt/pwx/oci/rootfs
+INFO[0000] SPEC CREATED [cc824f500363f0cf4e60c570cf9e8931  /opt/pwx/oci/config.json]
+INFO[0000] PX-RunC arguments: -c zox-dbg-mk126 -d enp0s8 -k etcd://70.0.0.65:2379 -m enp0s8 -s /dev/sdc -x kubernetes
+INFO[0000] PX-RunC mounts: /dev/:/dev/ /etc/hosts:/etc/hosts:ro /etc/pwx/:/etc/pwx/ /etc/resolv.conf:/etc/resolv.conf:ro /opt/pwx/bin/:/export_bin/ /lib/modules/:/lib/modules/ proc:/proc/:nosuid,noexec,nodev /run/docker/:/run/docker/ sysfs:/sys/:nosuid,noexec,nodev cgroup:/sys/fs/cgroup/:nosuid,noexec,nodev /usr/src/:/usr/src/ /var/cores/:/var/cores/ /var/run/:/var/host_run/ /var/lib/kubelet:/var/lib/kubelet:shared /var/lib/osd/:/var/lib/osd/:shared
+INFO[0000] PX-RunC env: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin TERM=xterm GOTRACEBACK=crash GOMAXPROCS=64 PXMOD_SOURCE=/home/px-fuse PXMOD_VERSION=5 BTRFS_SOURCE=/home/px_btrfs PX_RUNC=true
+INFO[0000] Successfully written /etc/systemd/system/portworx.service`, true},
+		{`INFO[0000] Rootfs found at /opt/pwx/oci/rootfs
+INFO[0000] SPEC UNCHANGED [cc824f500363f0cf4e60c570cf9e8931 /opt/pwx/oci/config.json]
+INFO[0000] PX-RunC arguments: -c zox-dbg-mk126 -d enp0s8 -k etcd://70.0.0.65:2379 -m enp0s8 -s /dev/sdc -x kubernetes
+INFO[0000] PX-RunC mounts: /dev/:/dev/ /etc/hosts:/etc/hosts:ro /etc/pwx/:/etc/pwx/ /etc/resolv.conf:/etc/resolv.conf:ro /opt/pwx/bin/:/export_bin/ /lib/modules/:/lib/modules/ proc:/proc/:nosuid,noexec,nodev /run/docker/:/run/docker/ sysfs:/sys/:nosuid,noexec,nodev cgroup:/sys/fs/cgroup/:nosuid,noexec,nodev /usr/src/:/usr/src/ /var/cores/:/var/cores/ /var/run/:/var/host_run/ /var/lib/kubelet:/var/lib/kubelet:shared /var/lib/osd/:/var/lib/osd/:shared
+INFO[0000] PX-RunC env: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin TERM=xterm GOTRACEBACK=crash GOMAXPROCS=64 PXMOD_SOURCE=/home/px-fuse PXMOD_VERSION=5 BTRFS_SOURCE=/home/px_btrfs PX_RUNC=true
+INFO[0000] Successfully written /etc/systemd/system/portworx.service`, false},
+	}
+
+	for _, v := range data {
+		assert.Equal(t, v.expectation, isRestartRequired(v.log),
+			"Was expecting isRestartRequired()=%v for `%s`", v.expectation, v.log)
+	}
+}

--- a/px-oci-mon/main_test.go
+++ b/px-oci-mon/main_test.go
@@ -39,6 +39,14 @@ INFO[0000] PX-RunC env: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/
 INFO[0000] Successfully written /etc/systemd/system/portworx.service`, false},
 	}
 
+	origFn := getKubernetesRootDirFn
+	getKubernetesRootDirFn = func() (string, error) {
+		return "/var/lib/kubelet", nil
+	}
+	defer func() {
+		getKubernetesRootDirFn = origFn
+	}()
+
 	for _, v := range data {
 		assert.Equal(t, v.expectation, isRestartRequired(v.log),
 			"Was expecting isRestartRequired()=%v for `%s`", v.expectation, v.log)

--- a/px-oci-mon/utils/inspect.go
+++ b/px-oci-mon/utils/inspect.go
@@ -24,6 +24,7 @@ type SimpleContainerConfig struct {
 const cgroupFileName = "/proc/self/cgroup"
 
 var (
+	// ErrContainerNotFound returned when no container can be found
 	ErrContainerNotFound = errors.New("container not found")
 	containerIDre        = regexp.MustCompilePOSIX(`[0-9]+:name=.*[/-]([0-9a-f]{64})`)
 )

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -55,7 +55,7 @@ func (di *DockerInstaller) PullImage(name string) error {
 }
 
 // RunOnce will create container, run it, wait until it's finished, and finally remove it.
-func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []string) error {
+func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []string, logWriter io.Writer) error {
 	contConf := container.Config{
 		Image:        name,
 		Cmd:          args,
@@ -116,7 +116,10 @@ func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []
 	if err != nil {
 		retError = fmt.Errorf("Could not get logs for container %s [%s]: %s", resp.ID, name, err)
 	}
-	io.Copy(os.Stdout, out)
+	if logWriter == nil {
+		logWriter = os.Stderr
+	}
+	io.Copy(logWriter, out)
 
 	if retError == nil {
 		logrus.Infof("Removing container %s [%s]", resp.ID, name)

--- a/px-oci-mon/utils/utils_test.go
+++ b/px-oci-mon/utils/utils_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetMyContainerID(t *testing.T) {
-	proc_self_cgroup_docker_v12 := `10:blkio:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
+	procSelfCgroupDockerV12 := `10:blkio:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
 9:freezer:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
 8:memory:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
 7:net_cls:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
@@ -17,12 +17,12 @@ func TestGetMyContainerID(t *testing.T) {
 2:cpuacct,cpu:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope
 1:name=systemd:/system.slice/docker-d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a.scope`
 
-	tripl := containerIDre.FindAllStringSubmatch(proc_self_cgroup_docker_v12, -1)
+	tripl := containerIDre.FindAllStringSubmatch(procSelfCgroupDockerV12, -1)
 	assert.Equal(t, 1, len(tripl))
 	assert.Equal(t, 2, len(tripl[0]))
 	assert.Equal(t, "d70eeb70bebdfa02dcbbda0e9aee666f38c0cba2e5664f1bc4eb0eb560932e7a", tripl[0][1])
 
-	proc_self_cgroup_docker_v17_06_2_ce := `11:blkio:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
+	procSelfCgroupDockerV17_06_2Ce := `11:blkio:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
 10:devices:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
 9:cpuacct,cpu:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
 8:net_prio,net_cls:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
@@ -34,7 +34,7 @@ func TestGetMyContainerID(t *testing.T) {
 2:memory:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667
 1:name=systemd:/kubepods/besteffort/pod002e671e-8c78-11e7-b787-525400ada096/d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667`
 
-	tripl = containerIDre.FindAllStringSubmatch(proc_self_cgroup_docker_v17_06_2_ce, -1)
+	tripl = containerIDre.FindAllStringSubmatch(procSelfCgroupDockerV17_06_2Ce, -1)
 	assert.Equal(t, 1, len(tripl))
 	assert.Equal(t, 2, len(tripl[0]))
 	assert.Equal(t, "d1b8179dbb75053ffcdc2a066f46f73d16dd5cce75a41c22f6363ba8102aa667", tripl[0][1])

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -321,12 +321,6 @@
 			"revisionTime": "2017-09-10T13:46:14Z"
 		},
 		{
-			"checksumSHA1": "BYvROBsiyAXK4sq6yhDe8RgT4LM=",
-			"path": "github.com/sirupsen/logrus",
-			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
-			"revisionTime": "2017-08-22T13:27:46Z"
-		},
-		{
 			"checksumSHA1": "nqWNlnMmVpt628zzvyo6Yv2CX5Q=",
 			"path": "golang.org/x/crypto/ssh/terminal",
 			"revision": "b0c9c05bfe149df95eb1d25642162cca051e0466",


### PR DESCRIPTION
PX-OCI service restarts no longer unconditional
* grabbing '# files updated' from rsync to trigger restart
* scanning mounts' changes, to disqualify kubelet/pod changes for restarts
  - (note: secrets content remains the same)
* additionally, cleaned up vendors.json, adding unit-tests