### PR TITLE
PWX-4128: [OCI] adding px/service controls

### DIFF
--- a/px-oci-mon/main.go
+++ b/px-oci-mon/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path"
 	"regexp"
@@ -37,6 +35,8 @@ var (
 	xtractKubeletRegex = regexp.MustCompile(`\s+--root-dir=(\S+)`)
 	debugsOn           = false
 	lastPxEnabled      = true
+	lastServiceCmd     = ""
+	ociService         *utils.OciServiceControl
 )
 
 // usage borrowed from ../../porx/cmd/px-runc/px-runc.go -- TODO: Consider refactoring !!
@@ -46,7 +46,7 @@ func usage(args ...interface{}) {
 		fmt.Fprintln(os.Stderr)
 	}
 
-	fmt.Printf(`Usage: %[1]s <install|uninstall> [options]
+	fmt.Printf(`Usage: %[1]s [options]
 
 options:
    -oci <dir>                Specify OCI directory (dfl: %[2]s)
@@ -63,7 +63,7 @@ options:
    -a                        Instructs PX to use any available, unused and unmounted drives
    -A                        Instructs PX to use any available, unused and unmounted drives or partitions
    -x <swarm|kubernetes>     Specify scheduler being used in the environment
-   -token <token>            Portworx lighthouse token for cluster
+   -t <token>                Portworx lighthouse token for cluster
 
 kvdb-options:
    -userpwd <user:passwd>    Username and password for ETCD authentication
@@ -73,31 +73,10 @@ kvdb-options:
    -acltoken <token>         ACL token value used for Consul authentication
 
 examples:
-   %[1]s install -k etcd://70.0.1.65:2379 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8
+   %[1]s -k etcd://70.0.1.65:2379 -c MY_CLUSTER_ID -s /dev/sdc -d enp0s8 -m enp0s8
 
 `, os.Args[0], baseDir, baseServiceName, fmt.Sprintf(baseServiceFileFmt, baseServiceName))
 	os.Exit(1)
-}
-
-func runExternalWithOutput(out io.Writer, name string, params ...string) error {
-	args := make([]string, 0, 4+len(params))
-	args = append(args, "/usr/bin/nsenter", "--mount="+hostProcMount, "--", name)
-	args = append(args, params...)
-
-	logrus.Info("> run: ", strings.Join(args[3:], " "))
-	logrus.Debugf(">>> %+v", args)
-	cmd := exec.Command(args[0], args[1:]...)
-	if out == nil {
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-	} else {
-		// note: exec.CombinedOutput() assigns to bytes.buffer, like we do
-		cmd.Stdout, cmd.Stderr = out, out
-	}
-	return cmd.Run()
-}
-
-func runExternal(name string, params ...string) error {
-	return runExternalWithOutput(nil, name, params...)
 }
 
 // Output filters --
@@ -155,9 +134,9 @@ func installPxFromOciImage(di *utils.DockerInstaller, imageName string, cfg *uti
 		logrus.Info("Installing Portworx OCI bits...")
 
 		// NOTE: This step is required, if px-runcds does not mount pwx-dirs
-		if err := runExternal("/bin/mkdir", "-p", "/opt/pwx", "/etc/pwx"); err != nil {
+		if err := ociService.RunExternal(nil, "/bin/mkdir", "-p", "/opt/pwx", "/etc/pwx"); err != nil {
 			logrus.WithError(err).Warn("Unable to create pwx directories directly -- retry via shell")
-			err = runExternal("/bin/sh", "-c", "mkdir -p /opt/pwx /etc/pwx")
+			err = ociService.RunExternal(nil, "/bin/sh", "-c", "mkdir -p /opt/pwx /etc/pwx")
 			if err != nil {
 				return true, fmt.Errorf("Unable to create pwx directories: %s", err)
 			}
@@ -207,7 +186,7 @@ func installPxFromOciImage(di *utils.DockerInstaller, imageName string, cfg *uti
 	// TODO: Add Labels?
 
 	var out cachingOutput
-	if err = runExternalWithOutput(&out, args[0], args[1:]...); err != nil {
+	if err = ociService.RunExternal(&out, args[0], args[1:]...); err != nil {
 		logrus.WithError(err).Error("Could not install PX-RunC")
 		return true, err
 	}
@@ -243,22 +222,6 @@ func validateMounts(mounts ...string) error {
 		}
 	}
 	return nil
-}
-
-func doRestart() {
-	logrus.Info("Reloading services")
-	err := runExternal("/bin/sh", "-c", "systemctl daemon-reload")
-	logrus.Info("Stopping Portworx service (if any)")
-	err = runExternal("/bin/sh", "-c", "systemctl stop portworx")
-	logrus.WithError(err).Debugf("Stopping done")
-
-	logrus.Info("Enabling and Starting Portworx service")
-	err = runExternal("/bin/sh", "-c",
-		`systemctl enable portworx && systemctl start portworx`)
-	if err != nil {
-		logrus.WithError(err).Error("Could not start Portworx service")
-		os.Exit(-1)
-	}
 }
 
 func doInstall() {
@@ -305,8 +268,13 @@ func doInstall() {
 	}
 
 	if isRestartRequired {
-		logrus.Warn("Restarting portworx service")
-		doRestart()
+		logrus.Warn("Reloading + Restarting portworx service")
+		err = ociService.Reload()
+		err = ociService.Restart()
+		if err != nil {
+			logrus.Error(err)
+			os.Exit(-1)
+		}
 	} else {
 		logrus.Info("Portworx service restart not required.")
 	}
@@ -314,44 +282,21 @@ func doInstall() {
 
 func doUninstall() {
 	logrus.Info("Stopping Portworx service")
-	var b bytes.Buffer
-	err := runExternalWithOutput(&b, "/bin/sh", "-c",
-		`systemctl stop portworx`)
-	if err != nil {
-		strerr := b.String()
-		if strings.Contains(strerr, " not loaded") {
-			logrus.Info(strerr)
-		} else {
-			logrus.WithError(err).Error("Could not stop Portworx service")
-			os.Exit(-1) // NOTE: CRITICAL failure !!
-		}
+	if err := ociService.Stop(); err != nil {
+		logrus.Error(err)
+		os.Exit(-1) // NOTE: CRITICAL failure !!
 	}
 
 	logrus.Info("Disabling Portworx service")
-	b.Reset()
-	err = runExternalWithOutput(&b, "/bin/sh", "-c",
-		`systemctl disable portworx`)
-	if err != nil {
-		strerr := b.String()
-		if strings.Contains(strerr, "No such file or directory") {
-			logrus.Info("Portworx service already disabled")
-		} else {
-			logrus.WithError(err).Error("Could not disable Portworx service")
-			os.Exit(-1) // NOTE: CRITICAL failure !!
-		}
+	if err := ociService.Disable(); err != nil {
+		logrus.Error(err)
+		os.Exit(-1) // NOTE: CRITICAL failure !!
 	}
 
-	logrus.Info("Removing Portworx service bind-mount (if any)")
-	err = runExternal("/bin/sh", "-c",
-		fmt.Sprintf(`grep -q ' %[1]s %[1]s ' /proc/self/mountinfo && umount %[1]s`, "/opt/pwx/oci"))
-	if err != nil {
-		logrus.WithError(err).Warn("Could not bind-umount Portworx files (continuing)")
-	}
-
-	logrus.Info("Removing Portworx files")
-	err = runExternal("/bin/rm", "-fr", "/opt/pwx", "/etc/systemd/system/portworx.service")
-	if err != nil {
-		logrus.WithError(err).Warn("Could not remove all Portworx files")
+	logrus.Info("Removing Portworx service bind-mount (if any) and uninstall")
+	if err := ociService.Remove(); err != nil {
+		logrus.Error(err)
+		os.Exit(-1) // NOTE: CRITICAL failure !!
 	}
 }
 
@@ -360,7 +305,7 @@ func getKubernetesRootDir() (string, error) {
 	logrus.Info("Locating kubelet's local state directory")
 	var out cachingOutput
 	args := strings.Fields(`/bin/ps --no-headers -o cmd -C kubelet`)
-	if err := runExternalWithOutput(&out, args[0], args[1:]...); err != nil {
+	if err := ociService.RunExternal(&out, args[0], args[1:]...); err != nil {
 		err = fmt.Errorf("Could not find kubelet service: %s", err)
 		return "", err
 	}
@@ -449,6 +394,43 @@ func unblockAndReplaySignals(sigs chan os.Signal) {
 	}
 }
 
+func watchNodeLabels(node *v1.Node) error {
+	logrus.Debugf("WATCH labels: %+v", node.GetLabels())
+	isPxEnabled := utils.IsPxEnabled(node)
+	if isPxEnabled && !lastPxEnabled {
+		logrus.Info("Requested PX-enablement via labels")
+		doInstall()
+		lastPxEnabled = true
+	} else if !isPxEnabled && lastPxEnabled {
+		logrus.Info("Requested PX-disablement via labels")
+		// temporarily block signals, until we process the uninstall
+		// (required to survive `docker stop`)
+		sigs := make(chan os.Signal, 1)
+		defer unblockAndReplaySignals(sigs)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		doUninstall()
+		lastPxEnabled = false
+	}
+
+	if req := utils.GetServiceRequest(node); req != "" {
+		if req == lastServiceCmd {
+			logrus.Debug("Ignoring service-request for ", req)
+		} else {
+			if err := ociService.HandleRequest(req); err != nil {
+				logrus.Error(err)
+			} else if req == "restart" {
+				// we're removing "restart" label, and keeping the others
+				utils.RemoveServiceLabel(node)
+				lastServiceCmd = ""
+			} else {
+				lastServiceCmd = req
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
 	// Debugs on?
 	if debugsOn = os.Getenv("DEBUG") != ""; !debugsOn {
@@ -462,6 +444,8 @@ func main() {
 	if debugsOn {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	ociService = utils.NewOciServiceControl(hostProcMount, baseServiceName)
 
 	meNode, err := utils.FindMyNode()
 	if err != nil || meNode == nil {
@@ -477,28 +461,10 @@ func main() {
 		lastOp = "Uninstall"
 	}
 
-	// install node-watcher to control the install/uninstall
 	logrus.Info("Activating node-watcher")
-	k8s.Instance().WatchNode(meNode, func(node *v1.Node) error {
-		if utils.IsPxEnabled(node) && !lastPxEnabled {
-			logrus.Info("Requested PX-enablement via labels")
-			doInstall()
-			lastPxEnabled = true
-		} else if !utils.IsPxEnabled(node) && lastPxEnabled {
-			logrus.Info("Requested PX-disablement via labels")
-			// temporarily block signals, until we process the uninstall
-			// (required to survive `docker stop`)
-			sigs := make(chan os.Signal, 1)
-			defer unblockAndReplaySignals(sigs)
-			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	k8s.Instance().WatchNode(meNode, watchNodeLabels)
 
-			doUninstall()
-			lastPxEnabled = false
-		}
-		return nil
-	})
-
-	// NOTE: we are DaemonSet entrypoint, so we should not exit
+	// NOTE: exiting the main() goroutine, the daemonSet is still maintained "alive" via Watcher
 	logrus.Info(lastOp, " done - MAIN exiting")
 	runtime.Goexit()
 	// normally unreachable

--- a/px-oci-mon/utils/kubernetes.go
+++ b/px-oci-mon/utils/kubernetes.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	hostnameKey   = "kubernetes.io/hostname"
 	enablementKey = "px/enabled"
-	configKey     = "px/config"
+	serviceKey    = "px/service"
 )
 
 // GetLocalIPList returns the list of local IP addresses, and optionally includes local hostname.
@@ -62,6 +61,20 @@ func IsPxEnabled(n *k8s_types.Node) bool {
 	}
 	logrus.Debugf("No px-enabled label found on node %s - assuming 'enabled'", n.GetName())
 	return true
+}
+
+// GetServiceRequest returns the state of the "px/service" label
+func GetServiceRequest(n *k8s_types.Node) string {
+	if lb, has := n.GetLabels()[serviceKey]; has {
+		return strings.ToLower(lb)
+	}
+	logrus.Debugf("No operation requested on node %s", n.GetName())
+	return ""
+}
+
+// RemoveServiceLabel deletes the operations label off the node
+func RemoveServiceLabel(n *k8s_types.Node) error {
+	return k8s.Instance().RemoveLabelOnNode(n.GetName(), serviceKey)
 }
 
 // FindMyNode finds LOCAL Node from Kubernetes env.

--- a/px-oci-mon/utils/service-control.go
+++ b/px-oci-mon/utils/service-control.go
@@ -1,0 +1,128 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	opSTART   = "start"
+	opSTOP    = "stop"
+	opRESTART = "restart"
+	opENABLE  = "enable"
+	opDISABLE = "disable"
+)
+
+// OciServiceControl provides "systemctl"-like controls over the external OCI service
+type OciServiceControl struct {
+	hostProcMount string
+	service       string
+}
+
+// NewOciServiceControl creates a new instance of ociServiceControl
+func NewOciServiceControl(mountNs, service string) *OciServiceControl {
+	return &OciServiceControl{mountNs, service}
+}
+
+// RunExternal is a generic runner of external commands
+func (o *OciServiceControl) RunExternal(out io.Writer, name string, params ...string) error {
+	args := make([]string, 0, 4+len(params))
+	args = append(args, "/usr/bin/nsenter", "--mount="+o.hostProcMount, "--", name)
+	args = append(args, params...)
+
+	logrus.Info("> run: ", strings.Join(args[3:], " "))
+	logrus.Debugf(">>> %+v", args)
+	cmd := exec.Command(args[0], args[1:]...)
+	if out == nil {
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	} else {
+		// note: exec.CombinedOutput() assigns to bytes.buffer, like we do
+		cmd.Stdout, cmd.Stderr = out, out
+	}
+	return cmd.Run()
+}
+
+func (o *OciServiceControl) do(op string) error {
+	logrus.Infof("Doing %s service %s", o.service, op)
+	var b bytes.Buffer
+	cmd := fmt.Sprintf("systemctl %s %s", op, o.service)
+	err := o.RunExternal(&b, "/bin/sh", "-c", cmd)
+	logrus.WithError(err).WithField("out", b.String()).Debugf("SVC %sed", op)
+	if err != nil {
+		err = fmt.Errorf("Could not %s service: %s", op, err)
+	}
+	return err
+}
+
+// Start the service
+func (o *OciServiceControl) Start() error {
+	return o.do(opSTART)
+}
+
+// Stop the service
+func (o *OciServiceControl) Stop() error {
+	return o.do(opSTOP)
+}
+
+// Restart the service
+func (o *OciServiceControl) Restart() error {
+	return o.do(opRESTART)
+}
+
+// Enable the service
+func (o *OciServiceControl) Enable() error {
+	return o.do(opENABLE)
+}
+
+// Disable the service
+func (o *OciServiceControl) Disable() error {
+	return o.do(opDISABLE)
+}
+
+// Reload the service files
+func (o *OciServiceControl) Reload() error {
+	var b bytes.Buffer
+	err := o.RunExternal(&b, "/bin/sh", "-c", `systemctl daemon-reload`)
+	logrus.WithError(err).WithField("out", b.String()).Debug("OCI reloaded")
+	if err != nil {
+		err = fmt.Errorf("Could not reload service: %s", err)
+	}
+	return err
+}
+
+// Remove the service files (called by Main directly)
+func (o *OciServiceControl) Remove() error {
+	logrus.Info("Removing service bind-mount (if any)")
+	err := o.RunExternal(nil, "/bin/sh", "-c",
+		fmt.Sprintf(`grep -q ' %[1]s %[1]s ' /proc/self/mountinfo && umount %[1]s`, "/opt/pwx/oci"))
+	if err != nil {
+		// log and attempt removal
+		logrus.WithError(err).Warn("Could not bind-umount Portworx files (continuing)")
+	}
+
+	logrus.Info("Removing Portworx files")
+	fname := fmt.Sprintf("/etc/systemd/system/%s.service", o.service)
+	err = o.RunExternal(nil, "/bin/rm", "-fr", "/opt/pwx", fname)
+	if err != nil {
+		err = fmt.Errorf("Could not remove all systemd files: %s", err)
+	}
+	return err
+}
+
+// HandleRequest will execute the systemctl -equivalent control command
+func (o *OciServiceControl) HandleRequest(op string) (err error) {
+	switch op {
+	case opSTART, opSTOP, opRESTART, opENABLE, opDISABLE:
+		return o.do(op)
+	// NOTE: INSTALL and UNINSTALL (REMOVE) is being handling via main()
+	default:
+		return fmt.Errorf("Unsupported service request: %s", op)
+	}
+	return err
+}

--- a/px-spec-websvc/templates/usage.html
+++ b/px-spec-websvc/templates/usage.html
@@ -205,7 +205,7 @@
         <td>
           <INPUT TYPE="text" NAME="t" VALUE="" onChange="proc(this.form)">
         </td>
-        <td><code>t:</code> Portworx lighthouse token for cluster. (example: <var>a980f3a8-5091-4d9c-871a-cbbeb030d1e6</var>)</td>
+        <td><code>t:</code> Portworx lighthouse token for cluster. (example: <var>token-a980f3a8-5091-4d9c-871a-cbbeb030d1e6</var>)</td>
       </tr>
       <tr>
         <td>


### PR DESCRIPTION
Refactored code to isolate OciServiceControl().
Adding new OCI-service controls via "px/service" node label: start, stop, restart, enable and disable
- note that "px/service=restart" is getting cleared, while all others will be persisted