### PR TITLE
PWX-4155, PWX-4146: OCI rolling upgrade fixes

### DIFF
--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -55,7 +55,13 @@ metadata:
 spec:
   minReadySeconds: 0
   updateStrategy:
-    type: {{if .IsRunC}}RollingUpdate{{else}}OnDelete{{end}}
+    {{- if .IsRunC}}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- else}}
+    type: OnDelete
+    {{- end}}
   template:
     metadata:
       labels:
@@ -107,6 +113,7 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
+            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /status
@@ -192,7 +199,13 @@ metadata:
 spec:
   minReadySeconds: 0
   updateStrategy:
+    {{- if .IsRunC}}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- else}}
     type: OnDelete
+    {{- end}}
   template:
     metadata:
       labels:
@@ -241,6 +254,7 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
+            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /status

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -55,7 +55,13 @@ metadata:
 spec:
   minReadySeconds: 0
   updateStrategy:
-    type: {{if .IsRunC}}RollingUpdate{{else}}OnDelete{{end}}
+    {{- if .IsRunC}}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- else}}
+    type: OnDelete
+    {{- end}}
   template:
     metadata:
       labels:
@@ -104,6 +110,7 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
+            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /status


### PR DESCRIPTION
Code:
- adding new PullImageCb() which uses callback to notify image will be downloaded
- stopping the OCI service before upgrade and/or PX-Image download
- OCI-service stop fixed to return OK when OCI service is not installed

Templates:
- adding 20 seconds delay to ReadinessProbe, so it doesn't report on stale OCI service during upgrades
- including rollingUpdate/maxUnavailable parameter (dfl. 1) to allow parallelization change during upgrades (ie. can define to sub-quorum for bigger PX-clusters)