### PR TITLE
PWX-4145,PWX-4156: OCI restart and reboot fixes

### DIFF
--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -128,12 +128,14 @@ spec:
             - name: libosd
               mountPath: /var/lib/osd:shared
             - name: etcpwx
-              mountPath: /etc/pwx/
+              mountPath: /etc/pwx
             {{- if .IsRunC}}
             - name: optpwx
-              mountPath: /opt/pwx/
+              mountPath: /opt/pwx
             - name: proc1nsmount
-              mountPath: /host_proc/1/ns/
+              mountPath: /host_proc/1/ns
+            - name: sysdmount
+              mountPath: /etc/systemd/system
             {{- else}}
             - name: dev
               mountPath: /dev
@@ -162,14 +164,17 @@ spec:
             path: /var/lib/osd
         - name: etcpwx
           hostPath:
-            path: /etc/pwx/
+            path: /etc/pwx
         {{- if .IsRunC}}
         - name: optpwx
           hostPath:
-            path: /opt/pwx/
+            path: /opt/pwx
         - name: proc1nsmount
           hostPath:
-            path: /proc/1/ns/
+            path: /proc/1/ns
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
         {{- else}}
         - name: dev
           hostPath:
@@ -269,12 +274,14 @@ spec:
             - name: libosd
               mountPath: /var/lib/osd:shared
             - name: etcpwx
-              mountPath: /etc/pwx/
+              mountPath: /etc/pwx
             {{- if .IsRunC}}
             - name: optpwx
-              mountPath: /opt/pwx/
+              mountPath: /opt/pwx
             - name: proc1nsmount
-              mountPath: /host_proc/1/ns/
+              mountPath: /host_proc/1/ns
+            - name: sysdmount
+              mountPath: /etc/systemd/system
             {{- else}}
             - name: dev
               mountPath: /dev
@@ -303,14 +310,17 @@ spec:
             path: /var/lib/osd
         - name: etcpwx
           hostPath:
-            path: /etc/pwx/
+            path: /etc/pwx
         {{- if .IsRunC}}
         - name: optpwx
           hostPath:
-            path: /opt/pwx/
+            path: /opt/pwx
         - name: proc1nsmount
           hostPath:
-            path: /proc/1/ns/
+            path: /proc/1/ns
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
         {{- else}}
         - name: dev
           hostPath:

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -76,10 +76,10 @@ spec:
                 operator: NotIn
                 values:
                 - "false"
-              {{if .MasterLess}}
+              {{- if .MasterLess}}
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
-              {{end}}
+              {{- end}}
       hostNetwork: true
       hostPID: true
       containers:
@@ -125,12 +125,14 @@ spec:
             - name: libosd
               mountPath: /var/lib/osd:shared
             - name: etcpwx
-              mountPath: /etc/pwx/
+              mountPath: /etc/pwx
             {{- if .IsRunC}}
             - name: optpwx
-              mountPath: /opt/pwx/
+              mountPath: /opt/pwx
             - name: proc1nsmount
-              mountPath: /host_proc/1/ns/
+              mountPath: /host_proc/1/ns
+            - name: sysdmount
+              mountPath: /etc/systemd/system
             {{- else}}
             - name: dev
               mountPath: /dev
@@ -146,9 +148,11 @@ spec:
               mountPath: /hostproc
             {{- end}}
       restartPolicy: Always
-      {{if .MasterLess}}{{else}}tolerations:
+      {{- if not .MasterLess}}
+      tolerations:
       - key: node-role.kubernetes.io/master
-        effect: NoSchedule{{end}}
+        effect: NoSchedule
+      {{- end}}
       serviceAccountName: px-account
       volumes:
         - name: dockersock
@@ -162,14 +166,17 @@ spec:
             path: /var/lib/osd
         - name: etcpwx
           hostPath:
-            path: /etc/pwx/
+            path: /etc/pwx
         {{- if .IsRunC}}
         - name: optpwx
           hostPath:
-            path: /opt/pwx/
+            path: /opt/pwx
         - name: proc1nsmount
           hostPath:
-            path: /proc/1/ns/
+            path: /proc/1/ns
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
         {{- else}}
         - name: dev
           hostPath:


### PR DESCRIPTION
Code [c4b62ca]:
- always restarts OCI if modifications of portworx.service detected
- always enable service if new portworx.service detected
- expect /etc/pwx, /opt/pwx and /etc/systemd/system to be mounted into oci-mon -- error out otherwise
- validateMounted() will now consolidate all invalid mounts before erroring out
- filtering PATH variable from ENV

Templates [13cc3ec]:
- adding '/etc/systemd/system' mount for OCI
- removed trailing '/' on directories
- fixing '.MasterLess' blank lines and rules