### PR TITLE
OCI uninstall fixes

### DIFF
--- a/px-oci-mon/main.go
+++ b/px-oci-mon/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/signal"
 	"path"
 	"regexp"
 	"runtime"
@@ -33,7 +32,7 @@ var (
 	// xtractKubeletRegex extracts /var/kubelet -override from running kubelet daemon
 	xtractKubeletRegex = regexp.MustCompile(`\s+--root-dir=(\S+)`)
 	debugsOn           = false
-	lastPxEnabled      = true
+	lastPxDisabled     = false
 	lastServiceCmd     = ""
 	ociService         *utils.OciServiceControl
 	ociPrivateMounts   = map[string]bool{
@@ -421,55 +420,37 @@ func isRestartRequired(in string) bool {
 	return false
 }
 
-func unblockAndReplaySignals(sigs chan os.Signal) {
-	signal.Reset(syscall.SIGINT, syscall.SIGTERM)
-	if len(sigs) > 0 {
-		s := <-sigs
-		switch s {
-		case syscall.SIGINT:
-			logrus.Warnf("Replaying interrupt")
-			syscall.Kill(syscall.Getpid(), syscall.SIGINT)
-		case syscall.SIGTERM:
-			logrus.Warnf("Replaying terminated")
-			syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
-		}
-	} else {
-		logrus.Debug("No signals to replay")
-	}
-}
-
+// watchNodeLabels monitors the label changes on the Node
+// NOTE: see https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 func watchNodeLabels(node *v1.Node) error {
 	logrus.Debugf("WATCH labels: %+v", node.GetLabels())
-	isPxEnabled := utils.IsPxEnabled(node)
-	if isPxEnabled && !lastPxEnabled {
+
+	isPxDisabled := utils.IsPxDisabled(node)
+	defer func() { lastPxDisabled = isPxDisabled }()
+	if !isPxDisabled && lastPxDisabled {
 		logrus.Info("Requested PX-enablement via labels")
 		doInstall()
-		lastPxEnabled = true
-	} else if !isPxEnabled && lastPxEnabled {
+	} else if isPxDisabled && !lastPxDisabled {
 		logrus.Info("Requested PX-disablement via labels")
-		// temporarily block signals, until we process the uninstall
-		// (required to survive `docker stop`)
-		sigs := make(chan os.Signal, 1)
-		defer unblockAndReplaySignals(sigs)
-		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-		doUninstall()
-		lastPxEnabled = false
-	}
-
-	if req := utils.GetServiceRequest(node); req != "" {
+		if utils.IsUninstallRequested(node) {
+			doUninstall()
+			utils.DisablePx(node)
+		} else {
+			logrus.Warn("Label 'px/enable=false' set directly, not removing the OCI install" +
+					" (use px/enable=remove to uninstall)")
+		}
+	} else if req := utils.GetServiceRequest(node); req != "" {
 		if req == lastServiceCmd {
 			logrus.Debug("Ignoring service-request for ", req)
-		} else {
-			if err := ociService.HandleRequest(req); err != nil {
-				logrus.Error(err)
-			} else if req == "restart" {
-				// we're removing "restart" label, and keeping the others
-				utils.RemoveServiceLabel(node)
-				lastServiceCmd = ""
-			} else {
-				lastServiceCmd = req
-			}
+			return nil
+		}
+		lastServiceCmd = req
+		if err := ociService.HandleRequest(req); err != nil {
+			logrus.Error(err)
+		} else if req == "restart" {
+			// we're removing "restart" label, and but keeping the others
+			utils.RemoveServiceLabel(node)
+			lastServiceCmd = ""
 		}
 	}
 	return nil
@@ -511,11 +492,11 @@ func main() {
 	}
 
 	lastOp := "Install"
-	if lastPxEnabled = utils.IsPxEnabled(meNode); lastPxEnabled {
-		err = doInstall()
-	} else {
+	if lastPxDisabled = utils.IsPxDisabled(meNode); lastPxDisabled {
 		err = doUninstall()
 		lastOp = "Uninstall"
+	} else {
+		err = doInstall()
 	}
 	if err != nil {
 		// note: CRITICAL FAILURE if install | uninstall failed

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -163,16 +163,18 @@ func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []
 	}
 	io.Copy(os.Stdout, out)
 
-	if retError == nil {
-		logrus.Infof("Removing container %s [%s]", resp.ID, name)
-		err = di.cli.ContainerRemove(di.ctx, resp.ID, types.ContainerRemoveOptions{
-			RemoveVolumes: true,
-			Force:         true,
-		})
-		if err != nil {
-			retError = fmt.Errorf("Could not remove container %s [%s]: %s", resp.ID, name, err)
-		}
-	}
+	//if retError == nil {
+	//	logrus.Infof("Removing container %s [%s]", resp.ID, name)
+	//	err = di.cli.ContainerRemove(di.ctx, resp.ID, types.ContainerRemoveOptions{
+	//		RemoveVolumes: true,
+	//		Force:         true,
+	//	})
+	//	if err != nil {
+	//		retError = fmt.Errorf("Could not remove container %s [%s]: %s", resp.ID, name, err)
+	//	}
+	//}
+	// CHECKME: Not removing the container, not to provike the fsync, also to keep the PX-image
+	logrus.Warnf("NOTE: Not removing the %s container [%s]", resp.ID, name)
 
 	return retError
 }

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -163,17 +163,9 @@ func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []
 	}
 	io.Copy(os.Stdout, out)
 
-	//if retError == nil {
-	//	logrus.Infof("Removing container %s [%s]", resp.ID, name)
-	//	err = di.cli.ContainerRemove(di.ctx, resp.ID, types.ContainerRemoveOptions{
-	//		RemoveVolumes: true,
-	//		Force:         true,
-	//	})
-	//	if err != nil {
-	//		retError = fmt.Errorf("Could not remove container %s [%s]: %s", resp.ID, name, err)
-	//	}
-	//}
-	// CHECKME: Not removing the container, not to provike the fsync, also to keep the PX-image
+	// CHECKME: Not removing the container, not to provoke the fsync, also to keep the PX-image
+	// > di.cli.ContainerRemove(di.ctx, resp.ID, types.ContainerRemoveOptions{RemoveVolumes: true, Force: true })
+
 	logrus.Warnf("NOTE: Not removing the %s container [%s]", resp.ID, name)
 
 	return retError

--- a/px-oci-mon/utils/kubernetes.go
+++ b/px-oci-mon/utils/kubernetes.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/v1"
+	k8s_types "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -21,7 +21,6 @@ var (
 		"false", // please keep first, keyword used w/ k8s uninstall
 		"uninstall",
 		"remove",
-		"disable",
 	}
 )
 
@@ -72,7 +71,7 @@ func in_array(needle string, stack ...string) (has bool) {
 }
 
 // IsPxDisabled reports if PX is disabled on this node.
-func IsPxDisabled(n *v1.Node) bool {
+func IsPxDisabled(n *k8s_types.Node) bool {
 	if lb, has := n.GetLabels()[enablementKey]; has {
 		lb = strings.ToLower(lb)
 		return in_array(lb, disabledLabels...)
@@ -82,7 +81,7 @@ func IsPxDisabled(n *v1.Node) bool {
 }
 
 // IsUninstallRequested reports if PX should uninstall on this node.
-func IsUninstallRequested(n *v1.Node) bool {
+func IsUninstallRequested(n *k8s_types.Node) bool {
 	if lb, has := n.GetLabels()[enablementKey]; has {
 		lb = strings.ToLower(lb)
 		return in_array(lb, disabledLabels[1:]...)
@@ -91,7 +90,7 @@ func IsUninstallRequested(n *v1.Node) bool {
 }
 
 // DisablePx will replace force-set label to "false", thus triggering the K8s uninstall
-func DisablePx(n *v1.Node) error {
+func DisablePx(n *k8s_types.Node) error {
 	lb, _ := n.GetLabels()[enablementKey]
 	lb = strings.ToLower(lb)
 	logrus.Warnf("Resetting k8s label '%s=%s' to '%s' -- expect cleanup by k8s",
@@ -100,7 +99,7 @@ func DisablePx(n *v1.Node) error {
 }
 
 // GetServiceRequest returns the state of the "px/service" label
-func GetServiceRequest(n *v1.Node) string {
+func GetServiceRequest(n *k8s_types.Node) string {
 	if lb, has := n.GetLabels()[serviceKey]; has {
 		return strings.ToLower(lb)
 	}
@@ -109,13 +108,13 @@ func GetServiceRequest(n *v1.Node) string {
 }
 
 // RemoveServiceLabel deletes the operations label off the node
-func RemoveServiceLabel(n *v1.Node) error {
+func RemoveServiceLabel(n *k8s_types.Node) error {
 	logrus.Infof("Removing k8s label %s=%s", serviceKey, GetServiceRequest(n))
 	return k8s.Instance().RemoveLabelOnNode(n.GetName(), serviceKey)
 }
 
 // FindMyNode finds LOCAL Node from Kubernetes env.
-func FindMyNode() (*v1.Node, error) {
+func FindMyNode() (*k8s_types.Node, error) {
 	ipList, err := GetLocalIPList(true)
 	if err != nil {
 		return nil, fmt.Errorf("Could not find my IPs/Hostname: %s", err)

--- a/px-oci-mon/utils/service-control.go
+++ b/px-oci-mon/utils/service-control.go
@@ -120,7 +120,7 @@ func (o *OciServiceControl) Remove() error {
 
 	logrus.Info("Removing Portworx files")
 	unitFile := fmt.Sprintf("/etc/systemd/system/%s.service", o.service)
-	err = o.RunExternal(nil, "/bin/rm", "-fr", ociDir, unitFile)
+	err = o.RunExternal(nil, "/bin/rm", "-fr", unitFile, ociDir )
 	if err != nil {
 		err = fmt.Errorf("Could not remove all systemd files: %s", err)
 	}


### PR DESCRIPTION
* removed signal-handling to prevent Docker's stop before uninstall
* label px/enabled=false will now just uninstall oci-monitor, leaving OCI-service up
* label px/enabled={uninstall,remove,disable} will cause OCI-service uninstall, followed by oci-monitor uninstall
* leaving the oci-installer container after the installation, to avoid fsync and px-enterprise container cleanup