### PR TITLE
Refactoring OCI-Monitor's upgrade

### DIFF
--- a/px-oci-mon/main.go
+++ b/px-oci-mon/main.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/portworx/px-installer/px-oci-mon/utils"
 	"github.com/portworx/sched-ops/k8s"
@@ -18,15 +17,15 @@ import (
 )
 
 const (
-	ociInstallerImage      = "portworx/px-enterprise:1.2.11.3"
-	ociInstallerNamePrefix = "px-oci-installer"
-	hostProcMount          = "/host_proc/1/ns/mnt"
-	baseDir                = "/opt/pwx/oci"
-	baseServiceName        = "portworx"
-	baseServiceFileFmt     = "/etc/systemd/system/%s.service"
-	pxConfigFile           = "/etc/pwx/config.json"
-	pxImageKey             = "PX_IMAGE"
-	pxImageIDKey           = "PX_IMAGE_ID"
+	ociInstallerImage  = "portworx/px-enterprise:1.2.11.3"
+	ociInstallerName   = "px-oci-installer"
+	hostProcMount      = "/host_proc/1/ns/mnt"
+	baseDir            = "/opt/pwx/oci"
+	baseServiceName    = "portworx"
+	baseServiceFileFmt = "/etc/systemd/system/%s.service"
+	pxConfigFile       = "/etc/pwx/config.json"
+	pxImageKey         = "PX_IMAGE"
+	pxImageIDKey       = "PX_IMAGE_ID"
 )
 
 var (
@@ -156,8 +155,6 @@ func installPxFromOciImage(di *utils.DockerInstaller, imageName string, cfg *uti
 			// do verbose rsync if debug is turned on
 			args = append(args, "--debug")
 		}
-
-		ociInstallerName := fmt.Sprintf("%s-%d", ociInstallerNamePrefix, time.Now().Unix())
 		err := di.RunOnce(imageName, ociInstallerName, []string{"/opt/pwx:/opt/pwx", "/etc/pwx:/etc/pwx"},
 			[]string{"/runc-entry-point.sh"}, args)
 		if err != nil {
@@ -440,7 +437,7 @@ func watchNodeLabels(node *v1.Node) error {
 			utils.DisablePx(node)
 		} else {
 			logrus.Warn("Label 'px/enable=false' set directly, not removing the OCI install" +
-				" (use px/enable=remove to uninstall)")
+					" (use px/enable=remove to uninstall)")
 		}
 	} else if req := utils.GetServiceRequest(node); req != "" {
 		if req == lastServiceCmd {

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -13,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const clientApiDefaultVersion = "1.23"
+const clientAPIDefaultVersion = "1.23"
 
 // DockerInstaller is a Docker client specialized for Container installation
 type DockerInstaller struct {
@@ -28,7 +29,7 @@ func NewDockerInstaller(user, pass string) (*DockerInstaller, error) {
 
 	cliVer := os.Getenv("DOCKER_API_VERSION")
 	if cliVer == "" {
-		cliVer = clientApiDefaultVersion
+		cliVer = clientAPIDefaultVersion
 	}
 
 	// NOTE: see https://docs.docker.com/engine/api/v1.26/#section/Versioning
@@ -56,6 +57,40 @@ func (di *DockerInstaller) PullImage(name string) error {
 	out, err := di.cli.ImagePull(di.ctx, name, opts)
 	if err != nil {
 		return err
+	}
+	_, err = io.Copy(os.Stdout, out)
+	return err
+}
+
+// DownloadNotifyCbFunc is used in conjunction with PullImageCb, to provide callback when "image pull" is downloading
+// the content (as opposed to {"status":"Status: Image is up to date for portworx/px-base:338f20e"})
+type DownloadNotifyCbFunc func() error
+
+// PullImageCb pulls the image of a given name. The CallBack function is called if image does not exist, and is being downloaded.
+func (di *DockerInstaller) PullImageCb(name string, cb DownloadNotifyCbFunc) error {
+	opts := types.ImagePullOptions{RegistryAuth: di.auth}
+	out, err := di.cli.ImagePull(di.ctx, name, opts)
+	if err != nil {
+		return err
+	}
+
+	initBuf := make([]byte, 512)
+	if n, err := io.ReadFull(out, initBuf); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			// this is an OK condition (incomplete read), copy the bytes we've got and exit
+			_, err = os.Stdout.Write(initBuf[0:n])
+			return err
+		}
+		return err
+	}
+	// based on initial read, let's determine if we started downloading layers
+	look4 := []byte(`"Pulling fs layer"`)
+	if bytes.Contains(initBuf, look4) && cb != nil {
+		if err := cb(); err != nil {
+			return err
+		}
+		// flush initial content, and continue...
+		os.Stdout.Write(initBuf)
 	}
 	_, err = io.Copy(os.Stdout, out)
 	return err

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -119,6 +119,13 @@ func (di *DockerInstaller) RunOnce(name, cntr string, binds, entrypoint, args []
 		AutoRemove: false,
 	}
 
+	logrus.Infof("Removing old container %s (if any)", cntr)
+	err := di.cli.ContainerRemove(di.ctx, cntr, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+		Force:         true,
+	})
+	logrus.WithError(err).Debug("Old container removed")
+
 	logrus.Info("Creating container from image ", name)
 	logrus.Debugf("> CONF: %+v  /  HOST: %+v", contConf, hostConf)
 	resp, err := di.cli.ContainerCreate(di.ctx, &contConf, &hostConf, nil, cntr)

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const clientApiDefaultVersion = "1.23"
+
 // DockerInstaller is a Docker client specialized for Container installation
 type DockerInstaller struct {
 	auth string
@@ -24,8 +26,13 @@ type DockerInstaller struct {
 func NewDockerInstaller(user, pass string) (*DockerInstaller, error) {
 	auth, ctx := "", context.Background()
 
+	cliVer := os.Getenv("DOCKER_API_VERSION")
+	if cliVer == "" {
+		cliVer = clientApiDefaultVersion
+	}
+
 	// NOTE: see https://docs.docker.com/engine/api/v1.26/#section/Versioning
-	cli, err := client.NewClient("unix:///var/run/docker.sock", "1.23", nil, nil)
+	cli, err := client.NewClient("unix:///var/run/docker.sock", cliVer, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/px-oci-mon/utils/installer.go
+++ b/px-oci-mon/utils/installer.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -50,40 +49,6 @@ func (di *DockerInstaller) PullImage(name string) error {
 	out, err := di.cli.ImagePull(di.ctx, name, opts)
 	if err != nil {
 		return err
-	}
-	_, err = io.Copy(os.Stdout, out)
-	return err
-}
-
-// DownloadNotifyCbFunc is used in conjunction with PullImageCb, to provide callback when "image pull" is downloading
-// the content (as opposed to {"status":"Status: Image is up to date for portworx/px-base:338f20e"})
-type DownloadNotifyCbFunc func() error
-
-// PullImageCb pulls the image of a given name. The CallBack function is called if image does not exist, and is being downloaded.
-func (di *DockerInstaller) PullImageCb(name string, cb DownloadNotifyCbFunc) error {
-	opts := types.ImagePullOptions{RegistryAuth: di.auth}
-	out, err := di.cli.ImagePull(di.ctx, name, opts)
-	if err != nil {
-		return err
-	}
-
-	initBuf := make([]byte, 512)
-	if n, err := io.ReadFull(out, initBuf); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			// this is an OK condition (incomplete read), copy the bytes we've got and exit
-			_, err = os.Stdout.Write(initBuf[0:n])
-			return err
-		}
-		return err
-	}
-	// based on initial read, let's determine if we started downloading layers
-	look4 := []byte(`"Pulling fs layer"`)
-	if bytes.Contains(initBuf, look4) && cb != nil {
-		if err := cb(); err != nil {
-			return err
-		}
-		// flush initial content, and continue...
-		os.Stdout.Write(initBuf)
 	}
 	_, err = io.Copy(os.Stdout, out)
 	return err

--- a/px-oci-mon/utils/kubernetes.go
+++ b/px-oci-mon/utils/kubernetes.go
@@ -21,6 +21,7 @@ var (
 		"false", // please keep first, keyword used w/ k8s uninstall
 		"uninstall",
 		"remove",
+		"rm",
 	}
 )
 
@@ -61,7 +62,7 @@ func GetLocalIPList(includeHostname bool) ([]string, error) {
 	return ipList, nil
 }
 
-func in_array(needle string, stack ...string) (has bool) {
+func inArray(needle string, stack ...string) (has bool) {
 	for i := range stack {
 		if has = needle == stack[i]; has {
 			break
@@ -74,7 +75,7 @@ func in_array(needle string, stack ...string) (has bool) {
 func IsPxDisabled(n *k8s_types.Node) bool {
 	if lb, has := n.GetLabels()[enablementKey]; has {
 		lb = strings.ToLower(lb)
-		return in_array(lb, disabledLabels...)
+		return inArray(lb, disabledLabels...)
 	}
 	logrus.Debugf("No px-enabled label found on node %s - assuming 'enabled'", n.GetName())
 	return false
@@ -84,7 +85,7 @@ func IsPxDisabled(n *k8s_types.Node) bool {
 func IsUninstallRequested(n *k8s_types.Node) bool {
 	if lb, has := n.GetLabels()[enablementKey]; has {
 		lb = strings.ToLower(lb)
-		return in_array(lb, disabledLabels[1:]...)
+		return inArray(lb, disabledLabels[1:]...)
 	}
 	return false
 }

--- a/px-oci-mon/utils/service-control.go
+++ b/px-oci-mon/utils/service-control.go
@@ -50,11 +50,11 @@ func (o *OciServiceControl) RunExternal(out io.Writer, name string, params ...st
 }
 
 func (o *OciServiceControl) do(op string, excludedErrorMsgs... string) error {
-	logrus.Infof("Doing %s service %s", o.service, op)
+	logrus.Infof("Doing systemctl %s %s", o.service, strings.ToUpper(op))
 	var b bytes.Buffer
 	cmd := fmt.Sprintf("systemctl %s %s", op, o.service)
 	err := o.RunExternal(&b, "/bin/sh", "-c", cmd)
-	logrus.WithError(err).WithField("out", b.String()).Debugf("SVC %sed", op)
+	logrus.WithError(err).WithField("out", b.String()).Debugf("SVC %sd", op)
 	if err != nil {
 		if len(excludedErrorMsgs) > 0 {
 			// Scan stderr output looking for provided segments that "clear" the error
@@ -67,7 +67,7 @@ func (o *OciServiceControl) do(op string, excludedErrorMsgs... string) error {
 				}
 			}
 		}
-		err = fmt.Errorf("Could not %s service: %s", op, err)
+		err = fmt.Errorf("Could not %s '%s' service: %s", op, o.service, err)
 	}
 	return err
 }
@@ -120,6 +120,7 @@ func (o *OciServiceControl) Remove() error {
 
 	logrus.Info("Removing Portworx files")
 	unitFile := fmt.Sprintf("/etc/systemd/system/%s.service", o.service)
+	// CHECKME: NOTE that this command can run locally (should we?)
 	err = o.RunExternal(nil, "/bin/rm", "-fr", unitFile, ociDir )
 	if err != nil {
 		err = fmt.Errorf("Could not remove all systemd files: %s", err)

--- a/px-oci-mon/utils/servlet.go
+++ b/px-oci-mon/utils/servlet.go
@@ -1,0 +1,205 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	httpHeaderServer      = "Server"
+	httpHeaderContentType = "Content-Type"
+	httpHeaderContentLen  = "Content-Length"
+	httpHeaderConnection  = "Connection"
+	ociServletPort        = 9015
+	nodeHealthURL         = "http://127.0.0.1:9001/v1/cluster/nodehealth"
+)
+
+type installState int
+
+const (
+	unknown installState = iota
+	installing
+	finished
+)
+
+// OciRESTServlet provides REST controls for OCI Monitor
+type OciRESTServlet struct {
+	ociCtl *OciServiceControl
+	lock   *sync.Mutex
+	cli    *http.Client
+	srv    *http.Server
+	state  installState
+}
+
+// NewRESTServlet returns new instance of the OciRESTServlet
+func NewRESTServlet(ctl *OciServiceControl) *OciRESTServlet {
+	return &OciRESTServlet{
+		ociCtl: ctl,
+		lock:   &sync.Mutex{},
+		cli: &http.Client{
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: 2,
+			},
+			Timeout: 5 * time.Second,
+		},
+		state: unknown,
+	}
+}
+
+// handleOciRest is a Servlet implementation passed to http.HandleFunc()
+func (s *OciRESTServlet) handleOciRest(resp http.ResponseWriter, req *http.Request) {
+	header := resp.Header()
+	header.Add(httpHeaderServer, "Portworx/OCI-monitor v1.0")
+
+	sendInvalidReq := func() {
+		resp.WriteHeader(http.StatusMethodNotAllowed)
+		header.Add(httpHeaderConnection, "close")
+	}
+
+	switch req.Method {
+
+	case http.MethodHead:
+		s.handleGetHead(resp, false)
+
+	case http.MethodGet:
+		s.handleGetHead(resp, true)
+
+	case http.MethodPost:
+		var err error
+		s.lock.Lock()
+		defer s.lock.Unlock()
+		if req.RequestURI == "/service/start" {
+			err = s.ociCtl.Start()
+		} else if req.RequestURI == "/service/stop" {
+			err = s.ociCtl.Stop()
+		} else if req.RequestURI == "/service/restart" {
+			err = s.ociCtl.Restart()
+		} else if req.RequestURI == "/service/enable" {
+			err = s.ociCtl.Enable()
+		} else if req.RequestURI == "/service/disable" {
+			err = s.ociCtl.Disable()
+		} else if req.RequestURI == "/service/remove" {
+			err = s.ociCtl.Remove()
+		} else {
+			logrus.Warnf("Ignoring REST call %s %s", req.Method, req.RequestURI)
+			sendInvalidReq()
+			break
+		}
+		if err == nil {
+			content := []byte(fmt.Sprintf("REST action%s completed successfully\n",
+				strings.ToUpper(strings.Replace(req.RequestURI, "/", " ", -1))))
+			header := resp.Header()
+			header.Add(httpHeaderContentType, "text/plain")
+			header.Add(httpHeaderContentLen, strconv.Itoa(len(content)))
+			resp.WriteHeader(http.StatusOK)
+			resp.Write(content)
+		} else {
+			logrus.WithError(err).Errorf("Error with REST call POST %s", req.RequestURI)
+			http.Error(resp, err.Error(), http.StatusInternalServerError)
+		}
+
+	default:
+		logrus.Warnf("Ignoring REST call %s %s", req.Method, req.RequestURI)
+		sendInvalidReq()
+	}
+	s.flush(resp)
+}
+
+// handleGetHead method is shared between the GET/HEAD calls.
+func (s *OciRESTServlet) handleGetHead(resp http.ResponseWriter, sendData bool) {
+
+	sendResp := func(code int, content []byte) {
+		if sendData {
+			header := resp.Header()
+			header.Add(httpHeaderContentType, "text/plain")
+			header.Add(httpHeaderContentLen, strconv.Itoa(len(content)))
+			resp.WriteHeader(code)
+			resp.Write(content)
+		} else {
+			resp.WriteHeader(code)
+		}
+	}
+	unknownStatusMsg := []byte("Node status UNKNOWN\n")
+
+	// If we're not finished installing (or, unknown), send status and return immediately
+	if st := s.getState(); st == unknown {
+		sendResp(http.StatusServiceUnavailable, unknownStatusMsg)
+		return
+	} else if s.getState() != finished {
+		sendResp(http.StatusServiceUnavailable, []byte("Node status INSTALLING\n"))
+		return
+	}
+
+	// Else, proxy PX status
+	pxResp, err := s.cli.Get(nodeHealthURL)
+	defer func() {
+		if pxResp != nil && pxResp.Body != nil {
+			pxResp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		logrus.WithError(err).Warn("Could not retrieve PX node status")
+		sendResp(http.StatusServiceUnavailable, unknownStatusMsg)
+		if pxResp != nil && pxResp.Body != nil {
+			logrus.Debug("Draining the invalid HTTP PX response") // .. so we can reuse keepalive session
+			ioutil.ReadAll(pxResp.Body)
+		}
+	} else {
+		content, err := ioutil.ReadAll(pxResp.Body)
+		if err != nil {
+			logrus.WithError(err).Warnf("Could not read PX node status")
+		}
+		sendResp(pxResp.StatusCode, content)
+	}
+}
+
+// SetStateInstalling sets the OCI state to installing
+func (s *OciRESTServlet) SetStateInstalling() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.state = installing
+}
+
+// SetStateInstallFinished sets the OCI state to finished installing
+func (s *OciRESTServlet) SetStateInstallFinished() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.state = finished
+}
+
+// getState returns the OCI installing status
+func (s *OciRESTServlet) getState() installState {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.state
+}
+
+// flush http-response implementation as suggested at
+// http://stackoverflow.com/questions/19292113/not-buffered-http-responsewritter-in-golang
+func (s *OciRESTServlet) flush(resp http.ResponseWriter) {
+	if f, ok := resp.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Start starts the OCI REST server
+func (s *OciRESTServlet) Start() {
+	if s.srv == nil {
+		http.HandleFunc("/", s.handleOciRest)
+		addr := fmt.Sprintf("127.0.0.1:%d", ociServletPort)
+		s.srv = &http.Server{Addr: addr}
+		go func() {
+			if err := s.srv.ListenAndServe(); err != nil {
+				logrus.WithError(err).Error("Could not start new HTTP server")
+			}
+		}()
+	}
+	// CHECKME is s.srv.Shutdown(nil) required?
+}

--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -116,7 +116,6 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
-            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /health
@@ -265,7 +264,6 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
-            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /health

--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -119,8 +119,8 @@ spec:
             initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
-              path: /v1/cluster/nodehealth
-              port: 9001
+              path: /health
+              port: 9015
           securityContext:
             privileged: true
           volumeMounts:
@@ -268,8 +268,8 @@ spec:
             initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
-              path: /v1/cluster/nodehealth
-              port: 9001
+              path: /health
+              port: 9015
           securityContext:
             privileged: true
           volumeMounts:

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -113,7 +113,6 @@ spec:
               port: 9001
           readinessProbe:
             periodSeconds: 10
-            initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
               path: /health

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -116,8 +116,8 @@ spec:
             initialDelaySeconds: 20
             httpGet:
               host: 127.0.0.1
-              path: /v1/cluster/nodehealth
-              port: 9001
+              path: /health
+              port: 9015
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
* PX-OCI service will be kept alive as long as possible, interruptions minimized to only directories-move and restart, which should not cause Docker to hang
* refactored PX-OCI install; install now happens without stopping old service, installs to alternative location, and directories are moved to the original place
* adding new health-check that is a composition of internal installation-status, and the PX-status
  - ie. if we're currently installing or downloading px-container, fail readyness checks, so k8s will know something's up, and not move to upgrading a new node
  - otherwise, proxy the PX `nodehealth` status
* finally, adjust the WebSVC to use the new readyness check, also remove it's startup delay