### PR TITLE
remove lighthouse support from spec homepage

### DIFF
--- a/px-spec-websvc/templates/usage.html
+++ b/px-spec-websvc/templates/usage.html
@@ -218,15 +218,9 @@
       </tr>
       <tr>
         <td>
-          <INPUT TYPE="text" NAME="t" VALUE="" onChange="proc(this.form)">
-        </td>
-        <td><code>t:</code> Portworx lighthouse token for cluster. (example: <var>token-a980f3a8-5091-4d9c-871a-cbbeb030d1e6</var>)</td>
-      </tr>
-      <tr>
-        <td>
           <INPUT TYPE="text" NAME="e" VALUE="" onChange="proc(this.form)">
         </td>
-        <td><code>e:</code> Comma-separated list of environment variables that will be exported to portworx. (example: <var>API_SERVER=http://lighthouse-new.portworx.com</var>)</td>
+        <td><code>e:</code> Comma-separated list of environment variables that will be exported to portworx. (example: <var>MYENV1=myvalue1,MYENV2=myvalue2</var>)</td>
         <tr>
     </table>
   </form>


### PR DESCRIPTION
As seen in softwaremotors, current lighthouse gives a half-baked experience and kicks out px scheduler integrations. Not supporting this is better. Also submitted docs PR to remove the -t and API_SERVER documentation.