### PR TITLE
ask for confirmation before and upgrade and automatically add talisman account to openshift privileged scc

### DIFF
--- a/px-spec-websvc/templates/k8s-px-upgrade.sh
+++ b/px-spec-websvc/templates/k8s-px-upgrade.sh
@@ -7,7 +7,7 @@ OPERATION=upgrade
 usage()
 {
   echo "
-  usage: [ [-o|--operation] <upgrade|restoresharedapps> [-t|--ocimontag] <new oci tag> --scaledownsharedapps <auto|on|off> ]
+  usage: [ [-O|--operation] <upgrade|restoresharedapps> [-t|--ocimontag] <new oci tag> --scaledownsharedapps <auto|on|off> ]
   examples:
             # (Default for no arguments) Upgrade Portworx using default image ($OCI_MON_IMAGE:$OCI_MON_TAG)
 
@@ -18,7 +18,7 @@ usage()
             -t 1.3.0-rc5
 
             # Restore shared Portworx applications back to their original replica counts in situation where previous upgrade job failed to restore them
-            -o restoresharedapps
+            -O restoresharedapps
        "
   exit
 }
@@ -38,7 +38,7 @@ while [ "$1" != "" ]; do
         -I | --talismanimage )  shift
                                 TALISMAN_IMAGE=$1
                                 ;;
-        -o | --operation )      shift
+        -O | --operation )      shift
                                 OPERATION=$1
                                 ;;
         -T | --talismantag )   shift


### PR DESCRIPTION
1. Now we require users to explicitly type "y" to proceed upgrade.
2. For openshift, we check if the system where the command is running has the oc binary as a loose check to figure out if this is an openshift system. This saves customers having to manually run `oc adm policy add-scc-to-user privileged system:serviceaccount:kube-system:talisman-account` like they do for PX install on openshift.

Test output:
```
The operation will upgrade Portworx to portworx/oci-monitor:1.3.0-rc4. Do you want to continue? [y/N] y
/usr/local/bin/oc
Detected openshift system. Adding talisman-account user to privileged scc
scc "privileged" added to: ["system:serviceaccount:kube-system:talisman-account"]
job "talisman" deleted
Parsed version is 1.7
serviceaccount "talisman-account" configured (dry run)
clusterrolebinding "talisman-role-binding" configured (dry run)
job "talisman" created (dry run)
Talisman job for upgrade started. Monitor logs using: 'kubectl logs -n kube-system -l job-name=talisman'
```

Signed-off-by: Harsh Desai <harsh@portworx.com>