### PR TITLE
PWX-4803 add additional node affinity rules to prevent PX from running on openshift master

### DIFF
--- a/px-spec-websvc/templates/k8s-master-worker-response.gtpl
+++ b/px-spec-websvc/templates/k8s-master-worker-response.gtpl
@@ -514,6 +514,11 @@ spec:
               {{- if .Openshift}}
               - key: openshift-infra
                 operator: Exists
+              - key: type
+                operator: In
+                values:
+                - "master"
+                - "infra"
               {{- else}}
               - key: node-role.kubernetes.io/master
                 operator: Exists
@@ -673,6 +678,11 @@ spec:
               {{- if .Openshift}}
               - key: openshift-infra
                 operator: DoesNotExist
+              - key: type
+                operator: NotIn
+                values:
+                - "master"
+                - "infra"
               {{- else}}
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist

--- a/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
+++ b/px-spec-websvc/templates/k8s-pxd-spec-response.gtpl
@@ -513,6 +513,11 @@ spec:
               {{- if .Openshift}}
               - key: openshift-infra
                 operator: DoesNotExist
+              - key: type
+                operator: NotIn
+                values:
+                - "master"
+                - "infra"
               {{- else}}
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist


### PR DESCRIPTION
BAH reported in their openshift install, their master and infra nodes has labels master and infra. Modifying the daemonset spec to accommodate that.

Signed-off-by: Harsh Desai <harsh@portworx.com>